### PR TITLE
Ensure Mastodon compatibility

### DIFF
--- a/salmon/magic.go
+++ b/salmon/magic.go
@@ -43,6 +43,10 @@ func encodeToString(b []byte) string {
 	return base64.RawURLEncoding.EncodeToString(b)
 }
 
+func signatureEncodeToString(b []byte) string {
+	return base64.URLEncoding.EncodeToString(b)
+}
+
 // FormatPublicKey formats a public key into the application/magic-key format.
 func FormatPublicKey(pk crypto.PublicKey) (string, error) {
 	switch pk := pk.(type) {
@@ -116,9 +120,9 @@ func PublicKeyID(pk crypto.PublicKey) (string, error) {
 }
 
 func computeHash(env *MagicEnv) ([]byte, error) {
-	mediaType := encodeToString([]byte(env.Data.Type))
-	encoding := encodeToString([]byte(env.Encoding))
-	alg := encodeToString([]byte(env.Alg))
+	mediaType := signatureEncodeToString([]byte(env.Data.Type))
+	encoding := signatureEncodeToString([]byte(env.Encoding))
+	alg := signatureEncodeToString([]byte(env.Alg))
 
 	h := sha256.New()
 	_, err := io.WriteString(h, env.Data.Value+"."+mediaType+"."+encoding+"."+alg)

--- a/xrd/client.go
+++ b/xrd/client.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"encoding/xml"
 	"errors"
+	"mime"
 	"net/http"
 )
 
@@ -28,14 +29,19 @@ func Get(url string) (*Resource, error) {
 		return nil, HTTPError(resp.StatusCode)
 	}
 
+	contentType, _, err := mime.ParseMediaType(resp.Header.Get("Content-Type"))
+	if err != nil {
+		return nil, err
+	}
+
 	resource := new(Resource)
-	switch resp.Header.Get("Content-Type") {
+	switch contentType {
 	case "application/xrd+xml", "application/xml", "text/xml":
 		err = xml.NewDecoder(resp.Body).Decode(resource)
 	case "application/jrd+json", "application/json", "":
 		err = json.NewDecoder(resp.Body).Decode(resource)
 	default:
-		err = errors.New("xrd: unsupported format")
+		err = errors.New("xrd: unsupported format: " + resp.Header.Get("Content-Type"))
 	}
 	return resource, err
 }


### PR DESCRIPTION
These changes ensure a Mastodon instance is capable of sending `/salmon` requests to an application driven by this library.

- Fixes the retrieval of `application/xrd+xml; charset=utf-8` content-types
- Fixes the signature hash calculation by using `URLEncoding` instead of `RawURLEncoding`

This change is integration-tested for retrieving salmon information from a Mastodon 2.6.1 instance. It should be tested for sending those information and for compatibility to other oStatus instances.